### PR TITLE
Add missing include guards to CBOR_streams.h

### DIFF
--- a/src/CBOR_streams.h
+++ b/src/CBOR_streams.h
@@ -3,6 +3,9 @@
 // This is part of libCBOR.
 // (c) 2017 Shawn Silverman
 
+#ifndef CBOR_STREAMS_H_
+#define CBOR_STREAMS_H_
+
 // Other includes
 #include <Print.h>
 #include <Stream.h>
@@ -191,3 +194,4 @@ class EEPROMPrint : public Print {
 
 }  // namespace cbor
 }  // namespace qindesign
+#endif


### PR DESCRIPTION
When including this header from multiple files, redefinition error occur because of the missing include guards